### PR TITLE
Add robots.txt to hexdocs assets

### DIFF
--- a/robots.txt
+++ b/robots.txt
@@ -1,0 +1,1 @@
+Sitemap: https://hexdocs.pm/sitemap.xml


### PR DESCRIPTION
I think this issue https://github.com/hexpm/hex_web/issues/190 can be closed after adding this robots.txt file. Both hexdocs and hex have the sitemaps and robots.txt now.
