### PR TITLE
Refactor search index building to work on Edge

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -96,11 +96,10 @@
           var xhttp = new XMLHttpRequest();
           xhttp.onreadystatechange = function() {
             if (this.readyState == XMLHttpRequest.DONE && this.status == 200) {
-              out=this.responseXML;
-              var iter, locs = this.responseXML.querySelectorAll("loc").values();
-              while (iter = locs.next()) {
-                if (iter.done) break;
-                var loc = iter.value.textContent;
+              out = this.responseXML;
+              var locs = this.responseXML.querySelectorAll("loc");
+              for (var idx = 0; idx < locs.length; idx++) {
+                var loc = locs[idx].textContent;
                 searchIndex.push({ name: loc.match("/(\\w+)/$")[1].toLowerCase(), url: loc });
               }
               addElixirCoreApps()


### PR DESCRIPTION
MS Edge's NodeList does not implement the iterable API (https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/5998615/), which prevented search from working on it. This change refactors away the iterable usage and replaces it with a for loop that works on Edge too.

I tested this with a local http server and a copy of the current hexdocs.pm sitemap with the latest Firefox, Firefox developer edition, Chrome and Edge, all on Win10.
