### PR TITLE
Fix extract name of package from location

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -99,8 +99,9 @@
               out = this.responseXML;
               var locs = this.responseXML.querySelectorAll("loc");
               for (var idx = 0; idx < locs.length; idx++) {
-                var loc = locs[idx].textContent;
-                searchIndex.push({ name: loc.match("/(\\w+)/$")[1].toLowerCase(), url: loc });
+                var loc = locs[idx].textContent.replace(/sitemap.xml$/, "");
+                var name = loc.match("/(\\w+)/$")[1].toLowerCase();
+                searchIndex.push({ name: name, url: loc });
               }
               addElixirCoreApps()
             }


### PR DESCRIPTION
Since https://github.com/hexpm/hexpm/pull/972 was merged, each location of package is a `sitemap.xml` of each package.

It breaks the Javascript of Hexdoc search page because the regular expression can't match new pattern of location.

This PR fix this issue.