### PR TITLE
Use HTTPS in homepage examples

### DIFF
--- a/index.html
+++ b/index.html
@@ -30,15 +30,15 @@
         </p>
 
         <p>
-          <code>http://hexdocs.pm/&lt;package&gt;/</code> - Latest documentation set for <code>package</code>
+          <code>https://hexdocs.pm/&lt;package&gt;/</code> - Latest documentation set for <code>package</code>
           <br>
-          Example: <code>http://hexdocs.pm/ecto/</code>
+          Example: <code>https://hexdocs.pm/ecto/</code>
         </p>
 
         <p>
-          <code>http://hexdocs.pm/&lt;package&gt;/&lt;version&gt;</code> - Documentation set for <code>package</code> at <code>version</code>
+          <code>https://hexdocs.pm/&lt;package&gt;/&lt;version&gt;</code> - Documentation set for <code>package</code> at <code>version</code>
           <br>
-          Example: <code>http://hexdocs.pm/ecto/1.1.9/</code>
+          Example: <code>https://hexdocs.pm/ecto/1.1.9/</code>
         </p>
 
         <p>


### PR DESCRIPTION
Modern browsers will redirect HTTP -> HTTPS anyway, but since hexdocs.pm is served over HTTPS I believe that's the better default to have in the homepage examples.