### PR TITLE
Fix: "Learn how to write documentation" href from "master" to "main"

### DIFF
--- a/index.html
+++ b/index.html
@@ -52,7 +52,7 @@
         </p>
 
         <p>
-          Learn how to write documentation <a href="https://hexdocs.pm/elixir/master/writing-documentation.html">here</a>.
+          Learn how to write documentation <a href="https://hexdocs.pm/elixir/main/writing-documentation.html">here</a>.
         </p>
         <br>
 


### PR DESCRIPTION
Ref: https://github.com/hexpm/hexpm/issues/1206